### PR TITLE
fix simple flaky test

### DIFF
--- a/src/test/java/snippets/SnippetsTests.java
+++ b/src/test/java/snippets/SnippetsTests.java
@@ -332,6 +332,7 @@ public class SnippetsTests {
         expected.put("c", 3);
 
         Map<String, Integer> picked = Snippets.pick(obj, new String[]{"a", "c"});
+        assertThat(picked.size() == obj.size());
         assertThat(picked).containsAllEntriesOf(expected);
     }
 

--- a/src/test/java/snippets/SnippetsTests.java
+++ b/src/test/java/snippets/SnippetsTests.java
@@ -327,8 +327,12 @@ public class SnippetsTests {
         obj.put("b", 2);
         obj.put("c", 3);
 
+        Map<String, Integer> expected = new HashMap<>();
+        expected.put("a", 1);
+        expected.put("c", 3);
+
         Map<String, Integer> picked = Snippets.pick(obj, new String[]{"a", "c"});
-        assertThat(picked).containsExactly(new SimpleEntry<>("a", 1), new SimpleEntry<>("c", 3));
+        assertThat(picked).containsAllEntriesOf(expected);
     }
 
     @Test


### PR DESCRIPTION
Change of https://github.com/MyEnthusiastic/30-seconds-of-java8/pull/1

The previous problem(flaky test) of containsExactly is that it compares the elements based on the order, so once we shuffle them the assertion would fail.

So my solution (thanks to the help of darko) would be use the containsAllEntriesOf to compare the current map between expected map 